### PR TITLE
add matic balance indicator

### DIFF
--- a/components/ConnectButton/index.tsx
+++ b/components/ConnectButton/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import Modal from "../Modal";
 import { useWeb3React } from "@web3-react/core";
 import { shortenAddress } from "../../utils";
@@ -7,13 +7,17 @@ import { Web3Provider } from "@ethersproject/providers";
 import { POLYGON_MAINNET_PARAMS } from '../../constants'
 import { injected } from '../../connectors'
 
+const utils = require('ethers').utils
+
 export default function index() {
 
   const [open, setOpen] = useState(false);
+  const [maticTokenBalance, setMaticTokenBalance] = useState<number>(0)
 
   const {
     chainId,
     account,
+    library,
   } = useWeb3React<Web3Provider>()
 
   async function switchToPolygon() {
@@ -29,15 +33,31 @@ export default function index() {
     })
   }
 
+  async function maticBalanceOf() {
+    var balance = await library.getSigner(account).getBalance()
+    var intBalance = utils.formatEther(balance)
+    setMaticTokenBalance(Number(intBalance))
+  }
+
+  useEffect(() => {
+    if (!account) return
+    maticBalanceOf()
+  }, [account])
+
   return (
     <>
       <Modal status={"connect"} open={open} setOpen={setOpen} />
 
-      <div className={'mr-2 hidden md:inline'}>
+      <div className="mr-2 hidden md:inline w-full border border-red-300 text-sm shadow-lg font-medium rounded-sm shadow-sm text-red-300 bg-gray-900 whitespace-nowrap focus:outline-none">
+        {account && (
+          <span className="px-6 border-r border-red-300">
+            {maticTokenBalance.toFixed(3)} MATIC
+          </span>
+        )}
         
         <button 
           onClick={(chainId !== 137 && !!account) ? () => switchToPolygon() : () => setOpen(true)}
-          className="px-6 w-full py-2 border border-red-300 hover:bg-gray-800 text-sm shadow-lg font-medium rounded-sm shadow-sm text-red-300 bg-gray-900 hover:shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500"
+          className="px-6 py-2 border-red-300 text-sm font-medium rounded-sm text-red-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500"
         >
 
             {(chainId !== 137) && "Switch to Polygon" }


### PR DESCRIPTION
This PR adds an indicator to the header to show the MATIC balance of the connected wallet.

### Connected Wallet

<img src="https://user-images.githubusercontent.com/1393139/123389242-4d466300-d55f-11eb-8887-81ef412e3f55.png" width="553" />

### Unconnected Wallet

<img src="https://user-images.githubusercontent.com/1393139/123389267-53d4da80-d55f-11eb-8a26-3dfcba2ea410.png" width="553" />
