### PR TITLE
refine place bid form ux

### DIFF
--- a/components/ConnectButton/index.tsx
+++ b/components/ConnectButton/index.tsx
@@ -4,20 +4,17 @@ import Modal from "../Modal";
 import { useWeb3React } from "@web3-react/core";
 import { shortenAddress } from "../../utils";
 import { Web3Provider } from "@ethersproject/providers";
+import { useMaticBalance } from '../../hooks/useMaticBalance';
 import { POLYGON_MAINNET_PARAMS } from '../../constants'
 import { injected } from '../../connectors'
 
-const utils = require('ethers').utils
-
 export default function index() {
-
   const [open, setOpen] = useState(false);
-  const [maticTokenBalance, setMaticTokenBalance] = useState<number>(0)
+  const maticBalance = useMaticBalance();
 
   const {
     chainId,
     account,
-    library,
   } = useWeb3React<Web3Provider>()
 
   async function switchToPolygon() {
@@ -32,18 +29,6 @@ export default function index() {
         })
     })
   }
-
-  async function maticBalanceOf() {
-    var balance = await library.getSigner(account).getBalance()
-    var intBalance = utils.formatEther(balance)
-    setMaticTokenBalance(Number(intBalance))
-  }
-
-  useEffect(() => {
-    if (!account) return
-    maticBalanceOf()
-  }, [account])
-
   return (
     <>
       <Modal status={"connect"} open={open} setOpen={setOpen} />
@@ -51,7 +36,7 @@ export default function index() {
       <div className="mr-2 hidden md:inline w-full border border-red-300 text-sm shadow-lg font-medium rounded-sm shadow-sm text-red-300 bg-gray-900 whitespace-nowrap focus:outline-none">
         {account && (
           <span className="px-6 border-r border-red-300">
-            {maticTokenBalance.toFixed(3)} MATIC
+            {maticBalance.toFixed(3)} MATIC
           </span>
         )}
         

--- a/components/SetSalePrice.tsx
+++ b/components/SetSalePrice.tsx
@@ -12,6 +12,7 @@ import { injected } from '../connectors'
 import { useRouter } from 'next/router'
 import { shortenAddress } from '../utils'
 import { getNetworkLibrary } from '../connectors'
+import { useMaticBalance } from '../hooks/useMaticBalance';
 import { BigNumber } from 'ethers'
 var utils = require('ethers').utils
 
@@ -35,6 +36,7 @@ const SetSalePrice: React.VFC<IProps> = ({ onUpdate, tokenId, sale = true }) => 
   const [bidder, setBidder] = useState<string | undefined>()
   const [ownerOf, setOwnerOf] = useState<boolean>(false)
   const [open, setOpen] = useState<boolean>(false)
+  const maticBalance = useMaticBalance();
   let transferTopic = ethers.utils.id('Transfer(address,address,uint256)')
 
   const handleSubmit = (evt) => {
@@ -42,6 +44,8 @@ const SetSalePrice: React.VFC<IProps> = ({ onUpdate, tokenId, sale = true }) => 
     // contract call
     console.log('VALUE', value)
   }
+
+  const hasError = account && value && maticBalance < parseFloat(value);
 
   // accept active bid
   async function createBid() {
@@ -82,7 +86,7 @@ const SetSalePrice: React.VFC<IProps> = ({ onUpdate, tokenId, sale = true }) => 
   setOpen={setOpen}
 />
       <label htmlFor="number" className="block text-sm font-medium text-white">
-        {sale ? 'Sale Price' : 'Place Bid'}
+        {sale ? 'Sale Price' : account && `Balance: ${maticBalance.toFixed(3)} MATIC`}
       </label>
       <form className="mt-5 sm:flex sm:items-center" onSubmit={handleSubmit}>
         <div className="w-full sm:max-w-xs">
@@ -113,7 +117,8 @@ const SetSalePrice: React.VFC<IProps> = ({ onUpdate, tokenId, sale = true }) => 
         ) : (
           <button
           onClick={!!account ? createBid : () => setOpen(true)}
-          className="ml-3 w-1/3 justify-center inline-flex items-center px-6 py-3 border border-red-300 shadow-sm text-red-300 font-medium rounded-xs text-white bg-gray-900 hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500"
+          className="button ml-3 w-1/3 justify-center inline-flex items-center px-6 py-3 border border-red-300 shadow-sm text-red-300 font-medium rounded-xs text-white bg-gray-900 hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500"
+          disabled={!maticBalance || !value || !parseFloat(value) || hasError}
         >
           Place Bid
           {loading && (
@@ -146,6 +151,10 @@ const SetSalePrice: React.VFC<IProps> = ({ onUpdate, tokenId, sale = true }) => 
         This should be a numeric value.
       </p>
     } */}
+
+      <span className={classNames({ invisible: !hasError}, "text-sm font-medium text-red-50")}>
+        You do not have enough MATIC for this bid.
+      </span>
     </div>
   )
 }

--- a/hooks/useMaticBalance.ts
+++ b/hooks/useMaticBalance.ts
@@ -1,0 +1,22 @@
+import { useState, useEffect } from 'react';
+import { utils } from 'ethers';
+import { useWeb3React } from '@web3-react/core';
+
+export function useMaticBalance() {
+  const [balance, setBalance] = useState(0);
+  const { account, library } = useWeb3React();
+
+  async function getMaticBalance() {
+    const balance = await library.getSigner(account).getBalance();
+    const intBalance = utils.formatEther(balance);
+    setBalance(Number(intBalance));
+  }
+
+  useEffect(() => {
+    if (account) {
+      getMaticBalance();
+    }
+  }, [account]);
+
+  return balance;
+}

--- a/styles/global.css
+++ b/styles/global.css
@@ -27,6 +27,10 @@ body {
     @apply opacity-60;
   }
 
+  .button[disabled]:hover {
+    cursor: not-allowed;
+  }
+
   .button--gradient {
     @apply primary-gradient-background;
   }


### PR DESCRIPTION
This PR refines a few things with the **Place Bid** form:

- Displays MATIC wallet balance (when wallet is connected) in input label instead of "Place Bid"
- Shows inline validation error message when bid exceeds connected wallet MATIC balance
- Disables **Place Bid** button when wallet is not connected, bid is <= 0, or bid exceeds connected wallet MATIC balance

Also extracted the logic to get the connected wallet's MATIC balance into a `useMaticBalance()` hook for reusability.

https://user-images.githubusercontent.com/1393139/123530450-f99f5b00-d6bf-11eb-9b74-54c37ea899f2.mp4
