### PR TITLE
handle uncaught errors

### DIFF
--- a/components/Error/index.tsx
+++ b/components/Error/index.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import Link from 'next/link';
+
+interface Props {
+  message: string;
+}
+
+export default function Error({ message }: Props) {
+  return (
+    <div className="flex mt-48 justify-center">
+      <div className="w-3/4 text-center">
+        <p className="text-2xl">{message}</p>
+
+        <p className="mt-4">If you think this is a bug, please contact the Screensaver team on <a href="https://discord.gg/r2DRdMctzh" className="text-red-300 hover:underline">Discord</a>.</p>
+
+        <Link href="/gallery?page=1">
+          <button className="button mt-6 w-72 justify-center inline-flex items-center px-6 py-3 border border-red-300 shadow-sm text-red-300 font-medium rounded-xs text-white bg-gray-900 hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500">Go to gallery</button>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/pages/ExploreView.tsx
+++ b/pages/ExploreView.tsx
@@ -140,11 +140,11 @@ const ExploreView: React.VFC<IProps> = ({ created, owned, admin }) => {
     let ids
 
     if (created) {
-      ids = data.account.created.map((i) => i.id)
+      ids = data.account?.created?.map((i) => i.id) ?? [];
     }
 
     if (owned) {
-      ids = data.account.items.map((i) => i.id)
+      ids = data.account?.items?.map((i) => i.id) ?? [];
     }
 
     let filteredIds = ids.filter((v, i) => ids.indexOf(v) === i)
@@ -255,6 +255,12 @@ const ExploreView: React.VFC<IProps> = ({ created, owned, admin }) => {
           }
         >
           OWNED&nbsp; <AccountId address={account.toString()} />
+        </div>
+      )}
+
+      {nfts.length === 0 && (
+        <div className="flex items-center justify-center text-md font-light h-12">
+          This address has no {created ? 'created' : owned ? 'owned' : ''} objects.
         </div>
       )}
 

--- a/pages/object/[tokenId].tsx
+++ b/pages/object/[tokenId].tsx
@@ -11,6 +11,7 @@ import BiddingDetailView from './BiddingDetailView'
 import Head from 'next/head'
 import ReportButton from '../../components/ReportButton'
 import BurnButton from '../../components/BurnButton'
+import Error from '../../components/Error'
 import { Web3Provider } from '@ethersproject/providers'
 import { useWeb3React } from '@web3-react/core'
 import { db, auth } from '../../config/firebase'
@@ -31,6 +32,7 @@ const ItemDetailPage: React.VFC = () => {
   const router = useRouter()
   const { tokenId, preview } = router.query
   const [uri, setUri] = useState<undefined | string>()
+  const [uriError, setUriError] = useState<string | null>(null)
   const [loading, setLoading] = useState<boolean>(true)
   const [metadata, setMetadata] = useState<NFT | undefined>()
   const [reports, setReports] = useState<string[]>([])
@@ -107,6 +109,7 @@ const ItemDetailPage: React.VFC = () => {
 
   async function getUri() {
     try {
+      setUriError(null);
       const contract = new ethers.Contract(
         process.env.NEXT_PUBLIC_CONTRACT_ID,
         GALLERY_ABI,
@@ -116,6 +119,7 @@ const ItemDetailPage: React.VFC = () => {
       setUri(tokenUri)
     } catch(error) {
       console.log("error", error)
+      setUriError(error);
     }
 
   }
@@ -142,6 +146,14 @@ const ItemDetailPage: React.VFC = () => {
       getUri()
     }
   }, [tokenId, preview])
+
+  if (uriError) {
+    return (
+      <Layout>
+        <Error message="There was an error loading this object." />
+      </Layout>
+    )
+  }
 
   if (loading)
     return (


### PR DESCRIPTION
This PR handles some uncaught error cases that cause the app to get stuck in a loading state.

## Invalid Object ID

Show the following error message when an object that doesn't exist is accessed (e.g. https://www.screensaver.world/object/1008) -- this can happen if the token was burned or the object ID isn't valid.

<img width="827" alt="Screen_Shot_2021-06-27_at_3 44 59_AM" src="https://user-images.githubusercontent.com/1393139/123558487-1f7a3d80-d75c-11eb-8902-b3022f9377cb.png">

## No created objects

<img width="416" alt="Screen_Shot_2021-06-27_at_3 41 01_AM" src="https://user-images.githubusercontent.com/1393139/123558481-18ebc600-d75c-11eb-8bff-288d4d17d7df.png">

## No owned objects

<img width="422" alt="Screen_Shot_2021-06-27_at_3 42 48_AM" src="https://user-images.githubusercontent.com/1393139/123558518-4cc6eb80-d75c-11eb-868b-e4a2864fb7a3.png">
