### PR TITLE
make entire page number container clickable

### DIFF
--- a/pages/ExploreView.tsx
+++ b/pages/ExploreView.tsx
@@ -312,8 +312,8 @@ const ExploreView: React.VFC<IProps> = ({ created, owned, admin }) => {
               containerClassName={
                 'flex w-full bg-red-400 justify-center items-center h-10'
               }
-              pageClassName={
-                'flex justify-center items-center w-10 bg-white text-red-400 m-2'
+              pageLinkClassName={
+                'flex justify-center items-center w-10 bg-white text-red-400 m-2 hover:cursor-pointer'
               }
               activeClassName={'active'}
             />


### PR DESCRIPTION
This PR updates the entire area of the gallery page number container to be clickable. Currently you have to click exactly on the page number text, which is not ideal UX.

### Before

https://user-images.githubusercontent.com/1393139/123702181-70576800-d828-11eb-9cb1-175fedae2ef8.mp4

### After

https://user-images.githubusercontent.com/1393139/123702179-6fbed180-d828-11eb-8146-af97a1c966fc.mp4